### PR TITLE
Feature/storage + filter sent notifications + pagination

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,11 @@
 # Local Spring profiles
 src/main/resources/application-local.yml
 
+# H2 Database files
+data/
+*.db
+*.trace.db
+
 # Gradle
 .gradle/
 build/

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,6 +13,8 @@ repositories { mavenCentral() }
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-validation")
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa") // For database storage
+    implementation("com.h2database:h2") // H2 in-memory database
 
     // HTTP client
     implementation("com.squareup.okhttp3:okhttp:4.12.0")

--- a/src/main/java/org/example/app/Application.java
+++ b/src/main/java/org/example/app/Application.java
@@ -3,13 +3,18 @@ package org.example.app;
 import org.example.infrastructure.telegram.TelegramProperties;
 import org.example.infrastructure.youtrack.YouTrackProperties;
 import org.example.infrastructure.scheduler.SchedulerProperties;
+import org.example.infrastructure.storage.StorageProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication(scanBasePackages = "org.example")
-@EnableConfigurationProperties({ YouTrackProperties.class, TelegramProperties.class, SchedulerProperties.class })
+@EnableConfigurationProperties({ YouTrackProperties.class, TelegramProperties.class, SchedulerProperties.class, StorageProperties.class })
+@EntityScan(basePackages = "org.example.infrastructure.storage")
+@EnableJpaRepositories(basePackages = "org.example.infrastructure.storage")
 @EnableScheduling
 public class Application {
     public static void main(String[] args) {

--- a/src/main/java/org/example/application/service/Formatter.java
+++ b/src/main/java/org/example/application/service/Formatter.java
@@ -29,9 +29,9 @@ public final class Formatter {
             sb.append("```\n").append(sanitizeForTripleBacktick(n.comment)).append("\n```\n");
         }
 
-        if (hasStar(n)) {
-            sb.append("star: ⭐\n");
-        }
+        // if (hasStar(n)) {
+        //     sb.append("star: ⭐\n");
+        // }
 
         if (notBlank(n.status)) {
             sb.append("Status: `").append(codeV2(n.status)).append("`\n");

--- a/src/main/java/org/example/application/service/NotificationScheduler.java
+++ b/src/main/java/org/example/application/service/NotificationScheduler.java
@@ -11,7 +11,7 @@ public class NotificationScheduler {
 
     private final NotifyIssueService notifyIssueService;
 
-    @Value("${scheduler.top:20}")
+    @Value("${scheduler.top:5}")
     private int top;
 
     public NotificationScheduler(NotifyIssueService notifyIssueService) {

--- a/src/main/java/org/example/application/service/NotifyIssueService.java
+++ b/src/main/java/org/example/application/service/NotifyIssueService.java
@@ -2,38 +2,130 @@ package org.example.application.service;
 
 import org.example.domain.port.IssueTrackerPort;
 import org.example.domain.port.MessengerPort;
+import org.example.domain.port.NotificationStoragePort;
 import org.example.domain.view.NotificationView;
+import org.example.infrastructure.scheduler.SchedulerProperties;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Service
 public class NotifyIssueService {
 
     private final IssueTrackerPort issueTrackerPort;
     private final MessengerPort messengerPort;
+    private final NotificationStoragePort storagePort;
+    private final SchedulerProperties schedulerProperties;
 
-    public NotifyIssueService(IssueTrackerPort issueTrackerPort, MessengerPort messengerPort) {
+    public NotifyIssueService(IssueTrackerPort issueTrackerPort, MessengerPort messengerPort, 
+                             NotificationStoragePort storagePort, SchedulerProperties schedulerProperties) {
         this.issueTrackerPort = issueTrackerPort;
         this.messengerPort = messengerPort;
+        this.storagePort = storagePort;
+        this.schedulerProperties = schedulerProperties;
     }
 
     public List<NotificationView> fetch(int top) throws IOException {
         return issueTrackerPort.fetchNotifications(top);
     }
 
+
     public void sendAllToGroup(int top) throws IOException {
-        System.out.println("Starting to fetch notifications, top=" + top);
-        List<NotificationView> list = fetch(top);
-        System.out.println("Fetched " + list.size() + " notifications");
-        for (NotificationView n : list) {
-            String msg = formatForTelegram(n);
-            System.out.println("Sending message: " + msg);
-            messengerPort.sendToGroup(msg);
+        System.out.println("Starting to fetch all notifications (ignoring top parameter)");
+
+        // Fetch all notifications (use a large number to get all)
+        List<NotificationView> allNotifications = fetch(1000); // Fetch up to 1000 notifications
+        System.out.println("Fetched " + allNotifications.size() + " total notifications");
+
+        // Debug: Print all notification IDs
+        for (NotificationView n : allNotifications) {
+            System.out.println("Notification ID: " + n.id + ", Issue ID: " + n.issueId + ", Title: " + n.title);
         }
-        System.out.println("All notifications sent successfully");
+
+        // Get all sent notification IDs from storage
+        Set<String> sentIds = storagePort.getAllSentIds();
+        System.out.println("Already sent " + sentIds.size() + " notifications");
+
+        // Filter out already sent notifications
+        List<NotificationView> newNotifications = allNotifications.stream()
+                .filter(n -> !sentIds.contains(n.id))
+                .collect(Collectors.toList());
+
+        System.out.println("Found " + newNotifications.size() + " new notifications (after deduplication)");
+
+        if (newNotifications.isEmpty()) {
+            System.out.println("No new notifications to send");
+            return;
+        }
+
+        // Send notifications with pagination
+        sendNotificationsWithPagination(newNotifications);
+
+        // Mark new notifications as sent
+        Set<String> newSentIds = newNotifications.stream()
+                .map(n -> n.id)
+                .collect(Collectors.toSet());
+        storagePort.markAsSent(newSentIds);
+        System.out.println("All new notifications sent successfully and marked as sent");
     }
+    
+    private void sendNotificationsWithPagination(List<NotificationView> notifications) throws IOException {
+        SchedulerProperties.Pagination pagination = schedulerProperties.getPagination();
+        
+        if (pagination.isEnabled()) {
+            // Send with pagination
+            int pageSize = pagination.getPageSize();
+            int delayMs = parseDurationToMs(pagination.getDelayBetweenMessages());
+            
+            System.out.println("Sending with pagination: pageSize=" + pageSize + ", delay=" + delayMs + "ms");
+            
+            for (int i = 0; i < notifications.size(); i += pageSize) {
+                int endIndex = Math.min(i + pageSize, notifications.size());
+                List<NotificationView> page = notifications.subList(i, endIndex);
+                
+                System.out.println("Sending page " + (i/pageSize + 1) + " (" + page.size() + " notifications)");
+                
+                for (NotificationView n : page) {
+                    String msg = formatForTelegram(n);
+                    System.out.println("Sending message: " + msg);
+                    messengerPort.sendToGroup(msg);
+                    
+                    if (delayMs > 0) {
+                        try {
+                            Thread.sleep(delayMs);
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                            break;
+                        }
+                    }
+                }
+            }
+        } else {
+            // Send all at once
+            for (NotificationView n : notifications) {
+                String msg = formatForTelegram(n);
+                System.out.println("Sending message: " + msg);
+                messengerPort.sendToGroup(msg);
+            }
+        }
+    }
+    
+    private int parseDurationToMs(String duration) {
+        // Simple parser for PT1S, PT2S, etc.
+        if (duration.startsWith("PT") && duration.endsWith("S")) {
+            try {
+                String seconds = duration.substring(2, duration.length() - 1);
+                return Integer.parseInt(seconds) * 1000;
+            } catch (NumberFormatException e) {
+                return 1000; // Default 1 second
+            }
+        }
+        return 1000; // Default 1 second
+    }
+    
 
     private String formatForTelegram(NotificationView n) {
         return Formatter.toTelegramMarkdown(n);

--- a/src/main/java/org/example/domain/port/IssueTrackerPort.java
+++ b/src/main/java/org/example/domain/port/IssueTrackerPort.java
@@ -7,6 +7,12 @@ import java.util.List;
 
 public interface IssueTrackerPort {
     List<NotificationView> fetchNotifications(int top) throws IOException;
+    
+    /**
+     * Fetch notifications from a specific timestamp cursor
+     * If timestamp is null, fetch all notifications
+     */
+    List<NotificationView> fetchNotificationsFromTimestamp(String timestampCursor, int top) throws IOException;
 }
 
 

--- a/src/main/java/org/example/domain/port/NotificationStoragePort.java
+++ b/src/main/java/org/example/domain/port/NotificationStoragePort.java
@@ -1,0 +1,45 @@
+package org.example.domain.port;
+
+import java.util.Set;
+
+public interface NotificationStoragePort {
+    /**
+     * Check if notification ID has been sent before
+     */
+    boolean isSent(String notificationId);
+    
+    /**
+     * Mark notification ID as sent
+     */
+    void markAsSent(String notificationId);
+
+    /**
+     * Mark notification ID as sent with timestamp information
+     */
+    void markAsSentWithTimestamp(String notificationId, String issueId, String title, String updatedTimestamp);
+
+    /**
+     * Mark multiple notification IDs as sent
+     */
+    void markAsSent(Set<String> notificationIds);
+    
+    /**
+     * Get all sent notification IDs
+     */
+    Set<String> getAllSentIds();
+    
+    /**
+     * Clear sent records (optional, for maintenance)
+     */
+    void clearSentRecords();
+    
+    /**
+     * Get the latest notification timestamp for cursor-based fetching
+     */
+    String getLatestNotificationTimestamp();
+
+    /**
+     * Update the latest notification timestamp
+     */
+    void updateLatestTimestamp(String timestamp);
+}

--- a/src/main/java/org/example/infrastructure/scheduler/SchedulerProperties.java
+++ b/src/main/java/org/example/infrastructure/scheduler/SchedulerProperties.java
@@ -8,6 +8,7 @@ public class SchedulerProperties {
     private String fixedDelay = "PT10M";     // ISO-8601 duration
     private String initialDelay = "PT10M";   // ISO-8601 duration
     private int top = 20;
+    private Pagination pagination = new Pagination();
 
     public boolean isEnabled() { return enabled; }
     public void setEnabled(boolean enabled) { this.enabled = enabled; }
@@ -17,6 +18,21 @@ public class SchedulerProperties {
     public void setInitialDelay(String initialDelay) { this.initialDelay = initialDelay; }
     public int getTop() { return top; }
     public void setTop(int top) { this.top = top; }
+    public Pagination getPagination() { return pagination; }
+    public void setPagination(Pagination pagination) { this.pagination = pagination; }
+
+    public static class Pagination {
+        private boolean enabled = false;
+        private int pageSize = 1;
+        private String delayBetweenMessages = "PT1S"; // ISO-8601 duration
+
+        public boolean isEnabled() { return enabled; }
+        public void setEnabled(boolean enabled) { this.enabled = enabled; }
+        public int getPageSize() { return pageSize; }
+        public void setPageSize(int pageSize) { this.pageSize = pageSize; }
+        public String getDelayBetweenMessages() { return delayBetweenMessages; }
+        public void setDelayBetweenMessages(String delayBetweenMessages) { this.delayBetweenMessages = delayBetweenMessages; }
+    }
 }
 
 

--- a/src/main/java/org/example/infrastructure/storage/DatabaseNotificationStorage.java
+++ b/src/main/java/org/example/infrastructure/storage/DatabaseNotificationStorage.java
@@ -1,0 +1,141 @@
+package org.example.infrastructure.storage;
+
+import org.example.domain.port.NotificationStoragePort;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class DatabaseNotificationStorage implements NotificationStoragePort {
+    
+    private final SentNotificationRepository repository;
+    
+    public DatabaseNotificationStorage(SentNotificationRepository repository) {
+        this.repository = repository;
+    }
+    
+    @Override
+    public boolean isSent(String notificationId) {
+        return repository.existsByNotificationId(notificationId);
+    }
+    
+    @Override
+    @Transactional
+    public void markAsSent(String notificationId) {
+        if (!repository.existsByNotificationId(notificationId)) {
+            SentNotification record = new SentNotification(notificationId, null, null, null);
+            repository.save(record);
+            System.out.println("[Storage] Marked notification " + notificationId + " as sent");
+        }
+    }
+
+    @Override
+    @Transactional
+    public void markAsSentWithTimestamp(String notificationId, String issueId, String title, String updatedTimestamp) {
+        if (!repository.existsByNotificationId(notificationId)) {
+            SentNotification record = new SentNotification(notificationId, issueId, title, updatedTimestamp);
+            repository.save(record);
+            System.out.println("[Storage] Marked notification " + notificationId + " as sent with timestamp " + updatedTimestamp);
+        }
+    }
+
+    @Override
+    @Transactional
+    public void markAsSent(Set<String> notificationIds) {
+        // Filter out already existing ones
+        List<String> existingIds = repository.findByNotificationIdIn(notificationIds)
+                .stream()
+                .map(SentNotification::getNotificationId)
+                .collect(Collectors.toList());
+
+        Set<String> newIds = new HashSet<>(notificationIds);
+        newIds.removeAll(existingIds);
+
+        if (!newIds.isEmpty()) {
+            List<SentNotification> records = newIds.stream()
+                    .map(id -> new SentNotification(id, null, null, null))
+                    .collect(Collectors.toList());
+
+            repository.saveAll(records);
+            System.out.println("[Storage] Marked " + newIds.size() + " notifications as sent");
+        }
+    }
+    
+    @Override
+    public Set<String> getAllSentIds() {
+        return repository.findAll()
+                .stream()
+                .map(SentNotification::getNotificationId)
+                .collect(Collectors.toSet());
+    }
+    
+    @Override
+    @Transactional
+    public void clearSentRecords() {
+        repository.deleteAll();
+        System.out.println("[Storage] Cleared all sent records");
+    }
+    
+    @Override
+    public String getLatestNotificationTimestamp() {
+        String latestTimestamp = repository.findLatestNotificationTimestamp();
+        System.out.println("[Storage] Latest notification timestamp: " + (latestTimestamp != null ? latestTimestamp : "none"));
+        return latestTimestamp;
+    }
+
+    @Override
+    @Transactional
+    public void updateLatestTimestamp(String timestamp) {
+        if (timestamp != null) {
+            // Create a special record to track the latest timestamp
+            // We'll use a special notification ID to identify this record
+            String timestampRecordId = "LATEST_TIMESTAMP_RECORD";
+            
+            // Delete existing timestamp record if any
+            repository.deleteById(timestampRecordId);
+            
+            // Create new timestamp record
+            SentNotification timestampRecord = new SentNotification(timestampRecordId, null, null, timestamp);
+            repository.save(timestampRecord);
+            
+            System.out.println("[Storage] Updated latest timestamp to: " + timestamp);
+        }
+    }
+    
+    /**
+     * Clean up old records (older than specified days)
+     */
+    @Transactional
+    public int cleanupOldRecords(int daysToKeep) {
+        LocalDateTime cutoffDate = LocalDateTime.now().minusDays(daysToKeep);
+        int deletedCount = repository.deleteBySentAtBefore(cutoffDate);
+        System.out.println("[Storage] Cleaned up " + deletedCount + " old records");
+        return deletedCount;
+    }
+    
+    /**
+     * Get storage statistics
+     */
+    public StorageStats getStats() {
+        long totalCount = repository.count();
+        return new StorageStats(totalCount);
+    }
+    
+    public static class StorageStats {
+        private final long totalRecords;
+        
+        public StorageStats(long totalRecords) {
+            this.totalRecords = totalRecords;
+        }
+        
+        public long getTotalRecords() { return totalRecords; }
+        
+        @Override
+        public String toString() {
+            return "StorageStats{totalRecords=" + totalRecords + "}";
+        }
+    }
+}

--- a/src/main/java/org/example/infrastructure/storage/SentNotification.java
+++ b/src/main/java/org/example/infrastructure/storage/SentNotification.java
@@ -1,0 +1,52 @@
+package org.example.infrastructure.storage;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "sent_notifications")
+public class SentNotification {
+    
+    @Id
+    @Column(name = "notification_id", length = 255)
+    private String notificationId;
+    
+    @Column(name = "sent_at", nullable = false)
+    private LocalDateTime sentAt;
+    
+    @Column(name = "issue_id", length = 100)
+    private String issueId;
+    
+    @Column(name = "title", length = 500)
+    private String title;
+
+    @Column(name = "updated_timestamp", length = 50)
+    private String updatedTimestamp;
+
+    // Default constructor for JPA
+    public SentNotification() {}
+
+    public SentNotification(String notificationId, String issueId, String title, String updatedTimestamp) {
+        this.notificationId = notificationId;
+        this.issueId = issueId;
+        this.title = title;
+        this.updatedTimestamp = updatedTimestamp;
+        this.sentAt = LocalDateTime.now();
+    }
+    
+    // Getters and setters
+    public String getNotificationId() { return notificationId; }
+    public void setNotificationId(String notificationId) { this.notificationId = notificationId; }
+    
+    public LocalDateTime getSentAt() { return sentAt; }
+    public void setSentAt(LocalDateTime sentAt) { this.sentAt = sentAt; }
+    
+    public String getIssueId() { return issueId; }
+    public void setIssueId(String issueId) { this.issueId = issueId; }
+    
+    public String getTitle() { return title; }
+    public void setTitle(String title) { this.title = title; }
+
+    public String getUpdatedTimestamp() { return updatedTimestamp; }
+    public void setUpdatedTimestamp(String updatedTimestamp) { this.updatedTimestamp = updatedTimestamp; }
+}

--- a/src/main/java/org/example/infrastructure/storage/SentNotificationRepository.java
+++ b/src/main/java/org/example/infrastructure/storage/SentNotificationRepository.java
@@ -1,0 +1,47 @@
+package org.example.infrastructure.storage;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
+
+@Repository
+public interface SentNotificationRepository extends JpaRepository<SentNotification, String> {
+    
+    /**
+     * Check if notification ID exists
+     */
+    boolean existsByNotificationId(String notificationId);
+    
+    /**
+     * Find notifications by issue ID
+     */
+    List<SentNotification> findByIssueId(String issueId);
+    
+    /**
+     * Delete old records (for maintenance)
+     */
+    @Modifying
+    @Query("DELETE FROM SentNotification s WHERE s.sentAt < :cutoffDate")
+    int deleteBySentAtBefore(LocalDateTime cutoffDate);
+    
+    /**
+     * Count total records
+     */
+    long count();
+    
+    /**
+     * Find notifications by IDs
+     */
+    List<SentNotification> findByNotificationIdIn(Set<String> notificationIds);
+    
+    /**
+     * Get the latest notification timestamp (for cursor-based fetching)
+     */
+    @Query("SELECT s.updatedTimestamp FROM SentNotification s WHERE s.updatedTimestamp IS NOT NULL ORDER BY s.updatedTimestamp DESC LIMIT 1")
+    String findLatestNotificationTimestamp();
+}

--- a/src/main/java/org/example/infrastructure/storage/StorageConfiguration.java
+++ b/src/main/java/org/example/infrastructure/storage/StorageConfiguration.java
@@ -1,0 +1,15 @@
+package org.example.infrastructure.storage;
+
+import org.example.domain.port.NotificationStoragePort;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class StorageConfiguration {
+    
+    @Bean
+    public NotificationStoragePort databaseNotificationStorage(SentNotificationRepository repository) {
+        return new DatabaseNotificationStorage(repository);
+    }
+}

--- a/src/main/java/org/example/infrastructure/storage/StorageProperties.java
+++ b/src/main/java/org/example/infrastructure/storage/StorageProperties.java
@@ -1,0 +1,23 @@
+package org.example.infrastructure.storage;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "storage")
+public class StorageProperties {
+    
+    private Cleanup cleanup = new Cleanup();
+    
+    public Cleanup getCleanup() { return cleanup; }
+    public void setCleanup(Cleanup cleanup) { this.cleanup = cleanup; }
+    
+    public static class Cleanup {
+        private boolean enabled = true;
+        private int daysToKeep = 30;
+        
+        public boolean isEnabled() { return enabled; }
+        public void setEnabled(boolean enabled) { this.enabled = enabled; }
+        
+        public int getDaysToKeep() { return daysToKeep; }
+        public void setDaysToKeep(int daysToKeep) { this.daysToKeep = daysToKeep; }
+    }
+}

--- a/src/main/java/org/example/interfaces/rest/NotificationController.java
+++ b/src/main/java/org/example/interfaces/rest/NotificationController.java
@@ -2,6 +2,7 @@ package org.example.interfaces.rest;
 
 import jakarta.validation.constraints.Min;
 import org.example.application.service.NotifyIssueService;
+import org.example.infrastructure.scheduler.SchedulerProperties;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -12,14 +13,17 @@ import org.springframework.web.bind.annotation.RestController;
 public class NotificationController {
 
     private final NotifyIssueService notifyIssueService;
+    private final SchedulerProperties schedulerProperties;
 
-    public NotificationController(NotifyIssueService notifyIssueService) {
+    public NotificationController(NotifyIssueService notifyIssueService, SchedulerProperties schedulerProperties) {
         this.notifyIssueService = notifyIssueService;
+        this.schedulerProperties = schedulerProperties;
     }
 
     @PostMapping("/broadcast")
-    public void broadcast(@RequestParam(name = "top", defaultValue = "20") @Min(1) int top) throws Exception {
-        notifyIssueService.sendAllToGroup(top);
+    public void broadcast(@RequestParam(name = "top", required = false) @Min(1) Integer top) throws Exception {
+        int actualTop = (top != null) ? top : schedulerProperties.getTop();
+        notifyIssueService.sendAllToGroup(actualTop);
     }
 }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,4 +20,27 @@ scheduler:
   initial-delay: PT10M
   top: 20
 
+storage:
+  cleanup:
+    enabled: true
+    days-to-keep: 30
+
+spring:
+  datasource:
+    url: jdbc:h2:file:./data/notificationdb
+    driver-class-name: org.h2.Driver
+    username: sa
+    password: 
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
+  jpa:
+    hibernate:
+      ddl-auto: update  # 改为update，保持数据持久化
+    show-sql: false
+    properties:
+      hibernate:
+        format_sql: true
+
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduce JPA/H2 storage to dedupe sent notifications, add configurable scheduler with pagination, and extend YouTrack client with timestamp filtering.
> 
> - **Storage (JPA/H2)**:
>   - Add `spring-boot-starter-data-jpa` and `com.h2database:h2`.
>   - Implement `NotificationStoragePort` with `DatabaseNotificationStorage`, entity `SentNotification`, and `SentNotificationRepository`.
>   - Wire via `StorageConfiguration`; add `StorageProperties`; persist sent IDs and latest timestamps.
> - **Scheduling & Pagination**:
>   - Add `NotificationScheduler` with `@Scheduled` using `scheduler.*` (`fixed-delay`, `initial-delay`, `top`).
>   - Add `SchedulerProperties` with nested `pagination` (page size, delay between messages).
>   - Enable scheduling/JPA via `Application` (`@EnableScheduling`, `@EntityScan`, `@EnableJpaRepositories`).
> - **Notification flow**:
>   - `NotifyIssueService`: fetch up to 1000, dedupe via storage, optional paginated sends, then mark new IDs as sent.
>   - `NotificationController`: `top` optional; default from `SchedulerProperties`.
> - **YouTrack client**:
>   - Add `fetchNotificationsFromTimestamp(...)`; support `updated` cursor; set `updated` field in `NotificationView`.
> - **Misc**:
>   - Suppress star line in `Formatter`.
>   - Configure H2 datasource and JPA in `application.yml`; ignore H2 files in `.gitignore`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 858f64e049f7d5eb5fc4fd708a0a8ef45aa569b9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->